### PR TITLE
A proof-of-concept implementation of busy indicator for QProgressBar

### DIFF
--- a/src/style/CMakeLists.txt
+++ b/src/style/CMakeLists.txt
@@ -1,6 +1,8 @@
 set(Adwaita_SRCS
     adwaita.cpp
     styleplugin.cpp
+    qstyleanimation.cpp
+    qstyleanimation_p.h
 )
 add_definitions(-DQT_PLUGIN)
 

--- a/src/style/adwaita.cpp
+++ b/src/style/adwaita.cpp
@@ -968,25 +968,50 @@ void Adwaita::drawControl(ControlElement element, const QStyleOption *opt, QPain
                 QCommonStyle::drawControl(element, opt, p, widget);
                 return;
             }
+            bool indeterminate = (pbopt->minimum == 0 && pbopt->maximum == 0);
             QRect rect = pbopt->rect.adjusted(0, 0, -1, -1);
             p->save();
-            if (pbopt->progress >= 0) {
+
+            if (!indeterminate) {
+                stopAnimation(widget);
+            }
+            else if (!animation(widget)) {
+                startAnimation(new QProgressStyleAnimation(animationFps, const_cast<QWidget*>(widget)));
+            }
+
+            if (indeterminate || pbopt->progress >= 0) {
                 QLinearGradient bgGrad;
                 if (pbopt2 && pbopt2->orientation == Qt::Horizontal) {
-                    qreal ratio = (((qreal) pbopt->progress) - pbopt->minimum) / (((qreal) pbopt->maximum) - pbopt->minimum);
-                    if (opt->version == 2 && pbopt2->invertedAppearance)
-                        rect.adjust(rect.width() * ratio, 0, 0, 0);
-                    else
-                        rect.setWidth(rect.width() * ratio);
+                    if (indeterminate) {
+                        int indicatorWidth = 0.20*rect.width();
+                        int indicatorOffset = qobject_cast<QProgressStyleAnimation*>(animation(widget))->progressStep(rect.width() - indicatorWidth);
+                        rect.adjust(indicatorOffset, 0, 0, 0);
+                        rect.setWidth(indicatorWidth);
+                    }
+                    else {
+                        qreal ratio = (((qreal) pbopt->progress) - pbopt->minimum) / (((qreal) pbopt->maximum) - pbopt->minimum);
+                        if (opt->version == 2 && pbopt2->invertedAppearance)
+                            rect.adjust(rect.width() * ratio, 0, 0, 0);
+                        else
+                            rect.setWidth(rect.width() * ratio);
+                    }
                     bgGrad = QLinearGradient(0.0, rect.top()+1, 0.0, rect.bottom()+1);
                 }
                 else {
-                    qreal ratio = (((qreal) pbopt->progress) - pbopt->minimum) / (((qreal) pbopt->maximum) - pbopt->minimum);
-                    if (pbopt2->invertedAppearance)
-                        rect.adjust(0, rect.height() * ratio, 0, 0);
-                    else
-                        rect.setHeight(rect.height() * ratio);
-                    bgGrad = QLinearGradient(rect.left()+1, 0.0, rect.right()+1, 0.0);
+                    if (indeterminate) {
+                        int indicatorHeight = 0.20*rect.height();
+                        int indicatorOffset = qobject_cast<QProgressStyleAnimation*>(animation(widget))->progressStep(rect.height() - indicatorHeight);
+                        rect.adjust(0, indicatorOffset, 0, 0);
+                        rect.setHeight(indicatorHeight);
+                    }
+                    else {
+                        qreal ratio = (((qreal) pbopt->progress) - pbopt->minimum) / (((qreal) pbopt->maximum) - pbopt->minimum);
+                        if (pbopt2->invertedAppearance)
+                            rect.adjust(0, rect.height() * ratio, 0, 0);
+                        else
+                            rect.setHeight(rect.height() * ratio);
+                        bgGrad = QLinearGradient(rect.left()+1, 0.0, rect.right()+1, 0.0);
+                    }
                 }
                 bgGrad.setColorAt(0.0, QColor("#4081C5"));
                 bgGrad.setColorAt(0.1, QColor("#4C91D9"));

--- a/src/style/adwaita.cpp
+++ b/src/style/adwaita.cpp
@@ -174,11 +174,6 @@ Adwaita::Adwaita()
 {
 }
 
-Adwaita::~Adwaita()
-{
-    qDeleteAll(animations);
-}
-
 void Adwaita::polish(QPalette &palette)
 {
     // All, used especially for active elements in a focused window

--- a/src/style/adwaita.cpp
+++ b/src/style/adwaita.cpp
@@ -975,7 +975,7 @@ void Adwaita::drawControl(ControlElement element, const QStyleOption *opt, QPain
             if (!indeterminate) {
                 stopAnimation(widget);
             }
-            else if (!animation(widget)) {
+            else if (!animations.value(widget)) {
                 startAnimation(new QProgressStyleAnimation(animationFps, const_cast<QWidget*>(widget)));
             }
 
@@ -983,8 +983,9 @@ void Adwaita::drawControl(ControlElement element, const QStyleOption *opt, QPain
                 QLinearGradient bgGrad;
                 if (pbopt2 && pbopt2->orientation == Qt::Horizontal) {
                     if (indeterminate) {
+                        QProgressStyleAnimation *animation = qobject_cast<QProgressStyleAnimation*>(animations.value(widget));
                         int indicatorWidth = 0.20*rect.width();
-                        int indicatorOffset = qobject_cast<QProgressStyleAnimation*>(animation(widget))->progressStep(rect.width() - indicatorWidth);
+                        int indicatorOffset = animation->progressStep(rect.width() - indicatorWidth);
                         rect.adjust(indicatorOffset, 0, 0, 0);
                         rect.setWidth(indicatorWidth);
                     }
@@ -999,8 +1000,9 @@ void Adwaita::drawControl(ControlElement element, const QStyleOption *opt, QPain
                 }
                 else {
                     if (indeterminate) {
+                        QProgressStyleAnimation *animation = qobject_cast<QProgressStyleAnimation*>(animations.value(widget));
                         int indicatorHeight = 0.20*rect.height();
-                        int indicatorOffset = qobject_cast<QProgressStyleAnimation*>(animation(widget))->progressStep(rect.height() - indicatorHeight);
+                        int indicatorOffset = animation->progressStep(rect.height() - indicatorHeight);
                         rect.adjust(0, indicatorOffset, 0, 0);
                         rect.setHeight(indicatorHeight);
                     }
@@ -1750,16 +1752,6 @@ QSize Adwaita::sizeFromContents(QStyle::ContentsType ct, const QStyleOption* opt
 
 
 // Animation support
-QList<const QObject*> Adwaita::animationTargets() const
-{
-    return animations.keys();
-}
-
-QStyleAnimation* Adwaita::animation(const QObject* target) const
-{
-    return animations.value(target);
-}
-
 void Adwaita::startAnimation(QStyleAnimation* animation) const
 {
     stopAnimation(animation->target());

--- a/src/style/adwaita.h
+++ b/src/style/adwaita.h
@@ -72,8 +72,6 @@ private:
     int animationFps;
     void _q_removeAnimation();
 
-    QList<const QObject*> animationTargets() const;
-    QStyleAnimation* animation(const QObject *target) const;
     void startAnimation(QStyleAnimation *animation) const;
     void stopAnimation(const QObject *target) const;
 

--- a/src/style/adwaita.h
+++ b/src/style/adwaita.h
@@ -68,9 +68,12 @@ public:
     QSize sizeFromContents(ContentsType ct, const QStyleOption* opt,
                            const QSize& contentsSize,
                            const QWidget* widget = 0) const;
+
+private slots:
+    void _q_removeAnimation();
+
 private:
     int animationFps;
-    void _q_removeAnimation();
 
     void startAnimation(QStyleAnimation *animation) const;
     void stopAnimation(const QObject *target) const;

--- a/src/style/adwaita.h
+++ b/src/style/adwaita.h
@@ -30,12 +30,15 @@
 #include <QCommonStyle>
 
 
+class QStyleAnimation; // qstyleanimation_p.h
+
 class Adwaita : public QCommonStyle
 {
     Q_OBJECT
 
 public:
     Adwaita();
+    virtual ~Adwaita();
 
     void polish(QPalette &palette);
     void polish(QWidget *widget);
@@ -66,6 +69,15 @@ public:
                            const QSize& contentsSize,
                            const QWidget* widget = 0) const;
 private:
+    int animationFps;
+    void _q_removeAnimation();
+
+    QList<const QObject*> animationTargets() const;
+    QStyleAnimation* animation(const QObject *target) const;
+    void startAnimation(QStyleAnimation *animation) const;
+    void stopAnimation(const QObject *target) const;
+
+    mutable QHash<const QObject*, QStyleAnimation*> animations;
 };
 
 #endif // ADWAITA_H

--- a/src/style/adwaita.h
+++ b/src/style/adwaita.h
@@ -38,7 +38,6 @@ class Adwaita : public QCommonStyle
 
 public:
     Adwaita();
-    virtual ~Adwaita();
 
     void polish(QPalette &palette);
     void polish(QWidget *widget);

--- a/src/style/qstyleanimation.cpp
+++ b/src/style/qstyleanimation.cpp
@@ -1,0 +1,362 @@
+/****************************************************************************
+**
+** Copyright (C) 2015 The Qt Company Ltd.
+** Contact: http://www.qt.io/licensing/
+**
+** This file is part of the QtWidgets module of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL21$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see http://www.qt.io/terms-conditions. For further
+** information use the contact form at http://www.qt.io/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 or version 3 as published by the Free
+** Software Foundation and appearing in the file LICENSE.LGPLv21 and
+** LICENSE.LGPLv3 included in the packaging of this file. Please review the
+** following information to ensure the GNU Lesser General Public License
+** requirements will be met: https://www.gnu.org/licenses/lgpl.html and
+** http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** As a special exception, The Qt Company gives you certain additional
+** rights. These rights are described in The Qt Company LGPL Exception
+** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#include "qstyleanimation_p.h"
+
+#ifndef QT_NO_ANIMATION
+
+#include <qcoreapplication.h>
+#include <qwidget.h>
+#include <qevent.h>
+
+QT_BEGIN_NAMESPACE
+
+static const qreal ScrollBarFadeOutDuration = 200.0;
+static const qreal ScrollBarFadeOutDelay = 450.0;
+
+QStyleAnimation::QStyleAnimation(QObject *target) : QAbstractAnimation(target),
+    _delay(0), _duration(-1), _startTime(QTime::currentTime()), _fps(ThirtyFps), _skip(0)
+{
+}
+
+QStyleAnimation::~QStyleAnimation()
+{
+}
+
+QObject *QStyleAnimation::target() const
+{
+    return parent();
+}
+
+int QStyleAnimation::duration() const
+{
+    return _duration;
+}
+
+void QStyleAnimation::setDuration(int duration)
+{
+    _duration = duration;
+}
+
+int QStyleAnimation::delay() const
+{
+    return _delay;
+}
+
+void QStyleAnimation::setDelay(int delay)
+{
+    _delay = delay;
+}
+
+QTime QStyleAnimation::startTime() const
+{
+    return _startTime;
+}
+
+void QStyleAnimation::setStartTime(const QTime &time)
+{
+    _startTime = time;
+}
+
+QStyleAnimation::FrameRate QStyleAnimation::frameRate() const
+{
+    return _fps;
+}
+
+void QStyleAnimation::setFrameRate(FrameRate fps)
+{
+    _fps = fps;
+}
+
+void QStyleAnimation::updateTarget()
+{
+    QEvent event(QEvent::StyleAnimationUpdate);
+    event.setAccepted(false);
+    QCoreApplication::sendEvent(target(), &event);
+    if (!event.isAccepted())
+        stop();
+}
+
+void QStyleAnimation::start()
+{
+    _skip = 0;
+    QAbstractAnimation::start(DeleteWhenStopped);
+}
+
+bool QStyleAnimation::isUpdateNeeded() const
+{
+    return currentTime() > _delay;
+}
+
+void QStyleAnimation::updateCurrentTime(int)
+{
+    if (++_skip >= _fps) {
+        _skip = 0;
+        if (target() && isUpdateNeeded())
+            updateTarget();
+    }
+}
+
+QProgressStyleAnimation::QProgressStyleAnimation(int speed, QObject *target) :
+    QStyleAnimation(target), _speed(speed), _step(-1)
+{
+}
+
+int QProgressStyleAnimation::animationStep() const
+{
+    return currentTime() / (1000.0 / _speed);
+}
+
+int QProgressStyleAnimation::progressStep(int width) const
+{
+    int step = animationStep();
+    int progress = (step * width / _speed) % width;
+    if (((step * width / _speed) % (2 * width)) >= width)
+        progress = width - progress;
+    return progress;
+}
+
+int QProgressStyleAnimation::speed() const
+{
+    return _speed;
+}
+
+void QProgressStyleAnimation::setSpeed(int speed)
+{
+    _speed = speed;
+}
+
+bool QProgressStyleAnimation::isUpdateNeeded() const
+{
+    if (QStyleAnimation::isUpdateNeeded()) {
+        int current = animationStep();
+        if (_step == -1 || _step != current)
+        {
+            _step = current;
+            return true;
+        }
+    }
+    return false;
+}
+
+QNumberStyleAnimation::QNumberStyleAnimation(QObject *target) :
+    QStyleAnimation(target), _start(0.0), _end(1.0), _prev(0.0)
+{
+    setDuration(250);
+}
+
+qreal QNumberStyleAnimation::startValue() const
+{
+    return _start;
+}
+
+void QNumberStyleAnimation::setStartValue(qreal value)
+{
+    _start = value;
+}
+
+qreal QNumberStyleAnimation::endValue() const
+{
+    return _end;
+}
+
+void QNumberStyleAnimation::setEndValue(qreal value)
+{
+    _end = value;
+}
+
+qreal QNumberStyleAnimation::currentValue() const
+{
+    qreal step = qreal(currentTime() - delay()) / (duration() - delay());
+    return _start + qMax(qreal(0), step) * (_end - _start);
+}
+
+bool QNumberStyleAnimation::isUpdateNeeded() const
+{
+    if (QStyleAnimation::isUpdateNeeded()) {
+        qreal current = currentValue();
+        if (!qFuzzyCompare(_prev, current))
+        {
+            _prev = current;
+            return true;
+        }
+    }
+    return false;
+}
+
+QBlendStyleAnimation::QBlendStyleAnimation(Type type, QObject *target) :
+    QStyleAnimation(target), _type(type)
+{
+    setDuration(250);
+}
+
+QImage QBlendStyleAnimation::startImage() const
+{
+    return _start;
+}
+
+void QBlendStyleAnimation::setStartImage(const QImage& image)
+{
+    _start = image;
+}
+
+QImage QBlendStyleAnimation::endImage() const
+{
+    return _end;
+}
+
+void QBlendStyleAnimation::setEndImage(const QImage& image)
+{
+    _end = image;
+}
+
+QImage QBlendStyleAnimation::currentImage() const
+{
+    return _current;
+}
+
+/*! \internal
+
+    A helper function to blend two images.
+
+    The result consists of ((alpha)*startImage) + ((1-alpha)*endImage)
+
+*/
+static QImage blendedImage(const QImage &start, const QImage &end, float alpha)
+{
+    if (start.isNull() || end.isNull())
+        return QImage();
+
+    QImage blended;
+    const int a = qRound(alpha*256);
+    const int ia = 256 - a;
+    const int sw = start.width();
+    const int sh = start.height();
+    const int bpl = start.bytesPerLine();
+    switch (start.depth()) {
+    case 32:
+        {
+            blended = QImage(sw, sh, start.format());
+            uchar *mixed_data = blended.bits();
+            const uchar *back_data = start.bits();
+            const uchar *front_data = end.bits();
+            for (int sy = 0; sy < sh; sy++) {
+                quint32* mixed = (quint32*)mixed_data;
+                const quint32* back = (const quint32*)back_data;
+                const quint32* front = (const quint32*)front_data;
+                for (int sx = 0; sx < sw; sx++) {
+                    quint32 bp = back[sx];
+                    quint32 fp = front[sx];
+                    mixed[sx] =  qRgba ((qRed(bp)*ia + qRed(fp)*a)>>8,
+                                        (qGreen(bp)*ia + qGreen(fp)*a)>>8,
+                                        (qBlue(bp)*ia + qBlue(fp)*a)>>8,
+                                        (qAlpha(bp)*ia + qAlpha(fp)*a)>>8);
+                }
+                mixed_data += bpl;
+                back_data += bpl;
+                front_data += bpl;
+            }
+        }
+    default:
+        break;
+    }
+    return blended;
+}
+
+void QBlendStyleAnimation::updateCurrentTime(int time)
+{
+    QStyleAnimation::updateCurrentTime(time);
+
+    float alpha = 1.0;
+    if (duration() > 0) {
+        if (_type == Pulse) {
+            time = time % duration() * 2;
+            if (time > duration())
+                time = duration() * 2 - time;
+        }
+
+        alpha = time / static_cast<float>(duration());
+
+        if (_type == Transition && time > duration()) {
+            alpha = 1.0;
+            stop();
+        }
+    } else if (time > 0) {
+        stop();
+    }
+
+    _current = blendedImage(_start, _end, alpha);
+}
+
+QScrollbarStyleAnimation::QScrollbarStyleAnimation(Mode mode, QObject *target) : QNumberStyleAnimation(target), _mode(mode), _active(false)
+{
+    switch (mode) {
+    case Activating:
+        setDuration(ScrollBarFadeOutDuration);
+        setStartValue(0.0);
+        setEndValue(1.0);
+        break;
+    case Deactivating:
+        setDuration(ScrollBarFadeOutDelay + ScrollBarFadeOutDuration);
+        setDelay(ScrollBarFadeOutDelay);
+        setStartValue(1.0);
+        setEndValue(0.0);
+        break;
+    }
+}
+
+QScrollbarStyleAnimation::Mode QScrollbarStyleAnimation::mode() const
+{
+    return _mode;
+}
+
+bool QScrollbarStyleAnimation::wasActive() const
+{
+    return _active;
+}
+
+void QScrollbarStyleAnimation::setActive(bool active)
+{
+    _active = active;
+}
+
+void QScrollbarStyleAnimation::updateCurrentTime(int time)
+{
+    QNumberStyleAnimation::updateCurrentTime(time);
+    if (_mode == Deactivating && qFuzzyIsNull(currentValue()))
+        target()->setProperty("visible", false);
+}
+
+QT_END_NAMESPACE
+
+#endif //QT_NO_ANIMATION

--- a/src/style/qstyleanimation.cpp
+++ b/src/style/qstyleanimation.cpp
@@ -100,7 +100,11 @@ void QStyleAnimation::setFrameRate(FrameRate fps)
 
 void QStyleAnimation::updateTarget()
 {
+#if QT_VERSION >= 0x050000
     QEvent event(QEvent::StyleAnimationUpdate);
+#else
+    QEvent event(QEvent::HoverEnter);
+#endif
     event.setAccepted(false);
     QCoreApplication::sendEvent(target(), &event);
     if (!event.isAccepted())

--- a/src/style/qstyleanimation.cpp
+++ b/src/style/qstyleanimation.cpp
@@ -98,18 +98,23 @@ void QStyleAnimation::setFrameRate(FrameRate fps)
     _fps = fps;
 }
 
+#if QT_VERSION >= 0x050000
 void QStyleAnimation::updateTarget()
 {
-#if QT_VERSION >= 0x050000
     QEvent event(QEvent::StyleAnimationUpdate);
-#else
-    QEvent event(QEvent::HoverEnter);
-#endif
     event.setAccepted(false);
     QCoreApplication::sendEvent(target(), &event);
     if (!event.isAccepted())
         stop();
 }
+#else
+void QStyleAnimation::updateTarget()
+{
+    QEvent event(QEvent::HoverEnter);
+    event.setAccepted(false);
+    QCoreApplication::sendEvent(target(), &event);
+}
+#endif
 
 void QStyleAnimation::start()
 {

--- a/src/style/qstyleanimation_p.h
+++ b/src/style/qstyleanimation_p.h
@@ -1,0 +1,200 @@
+/****************************************************************************
+**
+** Copyright (C) 2015 The Qt Company Ltd.
+** Contact: http://www.qt.io/licensing/
+**
+** This file is part of the QtWidgets module of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL21$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see http://www.qt.io/terms-conditions. For further
+** information use the contact form at http://www.qt.io/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 or version 3 as published by the Free
+** Software Foundation and appearing in the file LICENSE.LGPLv21 and
+** LICENSE.LGPLv3 included in the packaging of this file. Please review the
+** following information to ensure the GNU Lesser General Public License
+** requirements will be met: https://www.gnu.org/licenses/lgpl.html and
+** http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** As a special exception, The Qt Company gives you certain additional
+** rights. These rights are described in The Qt Company LGPL Exception
+** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef QSTYLEANIMATION_P_H
+#define QSTYLEANIMATION_P_H
+
+#include "qabstractanimation.h"
+#include "qdatetime.h"
+#include "qimage.h"
+
+QT_BEGIN_NAMESPACE
+
+#ifndef QT_NO_ANIMATION
+
+//
+//  W A R N I N G
+//  -------------
+//
+// This file is not part of the Qt API. It exists for the convenience of
+// qcommonstyle.cpp.  This header file may change from version to version
+// without notice, or even be removed.
+//
+// We mean it.
+//
+
+class QStyleAnimation : public QAbstractAnimation
+{
+    Q_OBJECT
+
+public:
+    QStyleAnimation(QObject *target);
+    virtual ~QStyleAnimation();
+
+    QObject *target() const;
+
+    int duration() const Q_DECL_OVERRIDE;
+    void setDuration(int duration);
+
+    int delay() const;
+    void setDelay(int delay);
+
+    QTime startTime() const;
+    void setStartTime(const QTime &time);
+
+    enum FrameRate {
+        DefaultFps,
+        SixtyFps,
+        ThirtyFps,
+        TwentyFps
+    };
+
+    FrameRate frameRate() const;
+    void setFrameRate(FrameRate fps);
+
+    void updateTarget();
+
+public Q_SLOTS:
+    void start();
+
+protected:
+    virtual bool isUpdateNeeded() const;
+    virtual void updateCurrentTime(int time) Q_DECL_OVERRIDE;
+
+private:
+    int _delay;
+    int _duration;
+    QTime _startTime;
+    FrameRate _fps;
+    int _skip;
+};
+
+class QProgressStyleAnimation : public QStyleAnimation
+{
+    Q_OBJECT
+
+public:
+    QProgressStyleAnimation(int speed, QObject *target);
+
+    int animationStep() const;
+    int progressStep(int width) const;
+
+    int speed() const;
+    void setSpeed(int speed);
+
+protected:
+    bool isUpdateNeeded() const Q_DECL_OVERRIDE;
+
+private:
+    int _speed;
+    mutable int _step;
+};
+
+class QNumberStyleAnimation : public QStyleAnimation
+{
+    Q_OBJECT
+
+public:
+    QNumberStyleAnimation(QObject *target);
+
+    qreal startValue() const;
+    void setStartValue(qreal value);
+
+    qreal endValue() const;
+    void setEndValue(qreal value);
+
+    qreal currentValue() const;
+
+protected:
+    bool isUpdateNeeded() const Q_DECL_OVERRIDE;
+
+private:
+    qreal _start;
+    qreal _end;
+    mutable qreal _prev;
+};
+
+class QBlendStyleAnimation : public QStyleAnimation
+{
+    Q_OBJECT
+
+public:
+    enum Type { Transition, Pulse };
+
+    QBlendStyleAnimation(Type type, QObject *target);
+
+    QImage startImage() const;
+    void setStartImage(const QImage& image);
+
+    QImage endImage() const;
+    void setEndImage(const QImage& image);
+
+    QImage currentImage() const;
+
+protected:
+    virtual void updateCurrentTime(int time) Q_DECL_OVERRIDE;
+
+private:
+    Type _type;
+    QImage _start;
+    QImage _end;
+    QImage _current;
+};
+
+class QScrollbarStyleAnimation : public QNumberStyleAnimation
+{
+    Q_OBJECT
+
+public:
+    enum Mode { Activating, Deactivating };
+
+    QScrollbarStyleAnimation(Mode mode, QObject *target);
+
+    Mode mode() const;
+
+    bool wasActive() const;
+    void setActive(bool active);
+
+private slots:
+    void updateCurrentTime(int time) Q_DECL_OVERRIDE;
+
+private:
+    Mode _mode;
+    bool _active;
+};
+
+#endif // QT_NO_ANIMATION
+
+QT_END_NAMESPACE
+
+#endif // QSTYLEANIMATION_P_H

--- a/src/style/qstyleanimation_p.h
+++ b/src/style/qstyleanimation_p.h
@@ -38,6 +38,12 @@
 #include "qdatetime.h"
 #include "qimage.h"
 
+/* Q_DECL_OVERRIDE is a Qt5 feature, add empty define to not break with Qt4 */
+#if QT_VERSION < 0x050000
+# define Q_DECL_OVERRIDE
+#endif
+
+
 QT_BEGIN_NAMESPACE
 
 #ifndef QT_NO_ANIMATION


### PR DESCRIPTION
This is a proof-of-concept implementation of a busy/activity indicator for QProgressBar (issue #47). It is largely inspired by the mainline Qt code, as well as the back-port of Fusion theme for Qt4 (https://github.com/jromang/fusion-qt4/).

As indicated in the commit messages, there are still couple of rough edges, but the main functionality is there. This PR is mostly intended as a starting point and a request for feedback on whether it is going in the right direction (especially w.r.t. the preferences on importing the code from the Qt code tree, etc.).