### PR TITLE
Set ButtonsHaveIcons hint to False

### DIFF
--- a/src/style/adwaita.cpp
+++ b/src/style/adwaita.cpp
@@ -334,6 +334,8 @@ int Adwaita::styleHint(StyleHint hint, const QStyleOption *opt, const QWidget *w
         case QStyle::SH_Menu_MouseTracking:
         case QStyle::SH_MenuBar_MouseTracking:
             return 1;
+        case QStyle::SH_DialogButtonBox_ButtonsHaveIcons:
+            return 0;
         default:
             return QCommonStyle::styleHint(hint, opt, widget, returnData);
     }


### PR DESCRIPTION
Currently standard buttons on dialogs have icons:

![about-qt](https://cloud.githubusercontent.com/assets/1381584/18411306/cdda9f96-7785-11e6-960b-49f1f2bdeadb.png)

This does not match what GNOME applications do since some GNOME 2.x version.
This pull request adds a style hint to fix this.