### PR TITLE
Dconf font setting

### DIFF
--- a/style/adwaitastyle.cpp
+++ b/style/adwaitastyle.cpp
@@ -35,6 +35,7 @@
 #include <QDial>
 #include <QDBusConnection>
 #include <QDockWidget>
+#include <QFont>
 #include <QFormLayout>
 #include <QGraphicsView>
 #include <QGroupBox>
@@ -304,17 +305,23 @@ namespace Adwaita
     {
         if( !app ) return;
 
-        QString fontName=readDconfSetting("font-name");
-        if (!fontName.isEmpty())
+        QByteArray desktop = qgetenv("XDG_CURRENT_DESKTOP").toLower();
+        QSet<QByteArray> gtkDesktops = QSet<QByteArray>() << "gnome" << "unity" << "pantheon";
+
+        if (gtkDesktops.contains(desktop))
         {
-            QStringList parts=fontName.split(' ', QString::SkipEmptyParts);
-            if (parts.length()>1)
+            QString fontName=readDconfSetting("font-name");
+            if (!fontName.isEmpty())
             {
-                uint size=parts.takeLast().toUInt();
-                if (size>5 && size<20)
+                QStringList parts=fontName.split(' ', QString::SkipEmptyParts);
+                if (parts.length()>1)
                 {
-                    QFont f(parts.join(" "), size);
-                    app->setFont(f);
+                    uint size=parts.takeLast().toUInt();
+                    if (size>5 && size<20)
+                    {
+                        QFont f(parts.join(" "), size);
+                        app->setFont(f);
+                    }
                 }
             }
         }

--- a/style/adwaitastyle.cpp
+++ b/style/adwaitastyle.cpp
@@ -43,16 +43,19 @@
 #include <QMdiSubWindow>
 #include <QMenu>
 #include <QPainter>
+#include <QProcess>
 #include <QPushButton>
 #include <QRadioButton>
 #include <QScrollBar>
 #include <QItemDelegate>
 #include <QSplitterHandle>
 #include <QTextEdit>
+#include <QTimer>
 #include <QToolBar>
 #include <QToolBox>
 #include <QToolButton>
 #include <QWidgetAction>
+
 
 namespace AdwaitaPrivate
 {
@@ -142,6 +145,48 @@ namespace AdwaitaPrivate
     };
 
 }
+
+static QString readDconfSetting(const QString &setting)
+{
+    // For some reason, dconf does not seem to terminate correctly when run under some desktops (e.g. KDE)
+    // Destroying the QProcess seems to block, causing the app to appear to hang before starting.
+    // So, create QProcess on the heap - and only wait 1.5s for response. Connect finished to deleteLater
+    // so that the object is destroyed.
+    QString schemeToUse=QLatin1String("/org/gnome/desktop/interface/");
+    QProcess *process=new QProcess();
+    process->start(QLatin1String("dconf"), QStringList() << QLatin1String("read") << schemeToUse+setting);
+    QObject::connect(process, SIGNAL(finished(int)), process, SLOT(deleteLater()));
+
+    if (process->waitForFinished(1500))
+    {
+        QString resp = process->readAllStandardOutput();
+        resp = resp.trimmed();
+        resp.remove('\'');
+
+        if (resp.isEmpty())
+        {
+            // Probably set to the default, and dconf does not store defaults! Therefore, need to read via gsettings...
+            schemeToUse=schemeToUse.mid(1, schemeToUse.length()-2).replace("/", ".");
+            QProcess *gsettingsProc=new QProcess();
+            gsettingsProc->start(QLatin1String("gsettings"), QStringList() << QLatin1String("get") << schemeToUse << setting);
+            QObject::connect(gsettingsProc, SIGNAL(finished(int)), process, SLOT(deleteLater()));
+            if (gsettingsProc->waitForFinished(1500))
+            {
+                resp = gsettingsProc->readAllStandardOutput();
+                resp = resp.trimmed();
+                resp.remove('\'');
+            }
+            else
+            {
+                gsettingsProc->kill();
+            }
+        }
+        return resp;
+    }
+    process->kill();
+    return QString();
+}
+
 
 void tabLayout(const QStyleOptionTabV3 *opt, const QWidget *widget, QRect *textRect, QRect *iconRect, const QStyle *proxyStyle) {
     Q_ASSERT(textRect);
@@ -252,6 +297,27 @@ namespace Adwaita
     Style::~Style( void )
     {
         delete _helper;
+    }
+
+    //______________________________________________________________
+    void Style::polish( QApplication* app )
+    {
+        if( !app ) return;
+
+        QString fontName=readDconfSetting("font-name");
+        if (!fontName.isEmpty())
+        {
+            QStringList parts=fontName.split(' ', QString::SkipEmptyParts);
+            if (parts.length()>1)
+            {
+                uint size=parts.takeLast().toUInt();
+                if (size>5 && size<20)
+                {
+                    QFont f(parts.join(" "), size);
+                    app->setFont(f);
+                }
+            }
+        }
     }
 
     //______________________________________________________________

--- a/style/adwaitastyle.h
+++ b/style/adwaitastyle.h
@@ -85,6 +85,9 @@ namespace Adwaita
         using  ParentStyleClass::polish;
         using  ParentStyleClass::unpolish;
 
+        //* application polishing
+        virtual void polish( QApplication* );
+
         //* widget polishing
         virtual void polish( QWidget* );
 


### PR DESCRIPTION
With Unbuntu GNOME 16.10 I noticed the Qt fonts were smaller than those of GNOME apps. This pull request reads the DConf font setting under GNOME desktops, and sets the Qt app to use this.