### PR TITLE
Add slight shadow to line-edts, etc

### DIFF
--- a/style/adwaitahelper.cpp
+++ b/style/adwaitahelper.cpp
@@ -430,6 +430,10 @@ namespace Adwaita
         // render
         painter->drawRoundedRect( frameRect, radius, radius );
 
+        if (!hasFocus) {
+            renderFrameShadow(painter, rect.adjusted(2, 2, -2, 2), outline);
+        }
+
     }
 
     //______________________________________________________________________________
@@ -473,12 +477,29 @@ namespace Adwaita
         path.addRect( frameRect.adjusted(2 * radius, 0, 0, 0) );
         painter->drawPath( path.simplified() );
 
+        if (!hasFocus) {
+            renderFrameShadow(painter, rect.adjusted(2, 2, -2, 2), outline);
+        }
+
         // render
         //painter->drawRoundedRect( frameRect, radius, radius );
 
     }
 
-    //______________________________________________________________________________
+    void Helper::renderFrameShadow(QPainter *painter, const QRect &rect, QColor shadow ) const
+    {
+        painter->save();
+        painter->setRenderHint(QPainter::Antialiasing, false);
+        shadow.setAlphaF(0.25);
+        painter->setPen( shadow );
+        painter->drawLine(rect.topLeft(), rect.topRight());
+        shadow.setAlphaF(0.1);
+        painter->setPen( shadow );
+        painter->drawLine(rect.topLeft()+QPoint(0, 1), rect.topRight()+QPoint(0, 1));
+        painter->restore();
+    }
+
+    //______________________________________________________________________________1
     void Helper::renderSidePanelFrame( QPainter* painter, const QRect& rect, const QColor& outline, Side side ) const
     {
 

--- a/style/adwaitahelper.h
+++ b/style/adwaitahelper.h
@@ -192,6 +192,8 @@ namespace Adwaita
         //* generic frame flat on right side
         void renderFlatFrame( QPainter*, const QRect&, const QColor& color, const QColor& outline = QColor(), bool hasFocus = false ) const;
 
+        void renderFrameShadow(QPainter *painter, const QRect &rect, QColor shadow ) const;
+
         //* side panel frame
         void renderSidePanelFrame( QPainter*, const QRect&, const QColor& outline, Side ) const;
 

--- a/style/adwaitastyle.cpp
+++ b/style/adwaitastyle.cpp
@@ -6805,8 +6805,10 @@ namespace Adwaita
             painter->setBrush(background);
             if (hasFocus)
                 painter->drawRect(arrowRect.adjusted(1, 3, -1, -2));
-            else
+            else {
                 painter->drawRect(arrowRect.adjusted(1, 2, -1, -1));
+                _helper->renderFrameShadow(painter, arrowRect.adjusted(1, 2, -1, 2), outline);
+            }
         }
 
         // render


### PR DESCRIPTION
Adwaita Gtk entry widgets, editable combos, and spin boxes have a very slight shadow at the top - this attempts to reproduce this for Adwaita Qt