### PR TITLE
Enable menu shadows for non-KDE desktops

### DIFF
--- a/style/adwaitastyle.cpp
+++ b/style/adwaitastyle.cpp
@@ -243,6 +243,10 @@ namespace Adwaita
             QStringLiteral( "org.kde.Adwaita.Style" ),
             QStringLiteral( "reparseConfiguration" ), this, SLOT(configurationChanged()) );
 
+        // Detect if running under KDE, if so set menus, etc, to have translucent background.
+        // For GNOME desktop, dont want translucent backgrounds otherwise no menu shadow is drawn.
+        _isKDE = qgetenv("XDG_CURRENT_DESKTOP").toLower()=="kde";
+
         // call the slot directly; this initial call will set up things that also
         // need to be reset when the system palette changes
         loadConfiguration();
@@ -6975,6 +6979,7 @@ namespace Adwaita
     //____________________________________________________________________________________
     void Style::setTranslucentBackground( QWidget* widget ) const
     {
+        if (!_isKDE) return;
         widget->setAttribute( Qt::WA_TranslucentBackground );
 
         #ifdef Q_WS_WIN

--- a/style/adwaitastyle.h
+++ b/style/adwaitastyle.h
@@ -520,6 +520,8 @@ namespace Adwaita
 
         bool _dark { false };
 
+        bool _isKDE { false };
+
         //@}
 
     };


### PR DESCRIPTION
Noticed that popup menus, etc, did not have shadows. This seems to fix the issue for me.