### PR TITLE
If using xcb system, then use dynamically loaded xcb functions to set _GTK_THEME_VARIANT

### DIFF
--- a/style/adwaitahelper.h
+++ b/style/adwaitahelper.h
@@ -333,6 +333,8 @@ namespace Adwaita
         qreal frameRadius( qreal bias = 0 ) const
         { return qMax( qreal( Metrics::Frame_FrameRadius ) - 0.5 + bias, 0.0 ); }
 
+        void setVariant(QWidget *widget, const QByteArray &variant);
+
         protected:
 
         //* initialize

--- a/style/adwaitastyle.cpp
+++ b/style/adwaitastyle.cpp
@@ -33,6 +33,7 @@
 #include <QCheckBox>
 #include <QComboBox>
 #include <QDial>
+#include <QDialog>
 #include <QDBusConnection>
 #include <QDockWidget>
 #include <QFormLayout>
@@ -407,6 +408,10 @@ namespace Adwaita
 
         }
 
+        if (qobject_cast<QDialog *>(widget) || qobject_cast<QMainWindow *>(widget)) {
+            addEventFilter( widget );
+        }
+
         // base class polishing
         ParentStyleClass::polish( widget );
 
@@ -494,7 +499,9 @@ namespace Adwaita
         if( qobject_cast<QAbstractScrollArea*>( widget ) ||
             qobject_cast<QDockWidget*>( widget ) ||
             qobject_cast<QMdiSubWindow*>( widget ) ||
-            widget->inherits( "QComboBoxPrivateContainer" ) )
+            widget->inherits( "QComboBoxPrivateContainer" ) ||
+            qobject_cast<QDialog *>(widget) ||
+            qobject_cast<QMainWindow *>(widget))
             { widget->removeEventFilter( this ); }
 
         ParentStyleClass::unpolish( widget );
@@ -1201,6 +1208,11 @@ namespace Adwaita
         QWidget *widget = static_cast<QWidget*>( object );
         if( widget->inherits( "QAbstractScrollArea" ) || widget->inherits( "KTextEditor::View" ) ) { return eventFilterScrollArea( widget, event ); }
         else if( widget->inherits( "QComboBoxPrivateContainer" ) ) { return eventFilterComboBoxContainer( widget, event ); }
+
+        if ((qobject_cast<QDialog *>(widget) || qobject_cast<QMainWindow *>(widget)) &&
+                (QEvent::Show==event->type() || QEvent::StyleChange==event->type())) {
+            _helper->setVariant(widget, _dark ? "dark" : "light");
+        }
 
         // fallback
         return ParentStyleClass::eventFilter( object, event );


### PR DESCRIPTION
Second attempt at setting dark titlebars for Adwaita-Dark.

This uses QLibrary to dynamically load libxcb, and then resolve the used functions. There's also some copied types from xcb. This was so that Adwaita has neither a compile nor link time dependency upon xcb.