### PR TITLE
MSVC2015 compatibility

### DIFF
--- a/style/CMakeLists.txt
+++ b/style/CMakeLists.txt
@@ -43,6 +43,10 @@ set(Adwaita_SRCS
 )
 add_definitions(-DQT_PLUGIN)
 
+if (MSVC)
+    add_definitions(-D_USE_MATH_DEFINES) # Needed for M_PI on MSVC
+endif()
+
 include_directories(
     ${QT_INCLUDES}
     ${CMAKE_CURRENT_BINARY_DIR}

--- a/style/adwaitahelper.cpp
+++ b/style/adwaitahelper.cpp
@@ -1339,22 +1339,22 @@ namespace Adwaita
         painter->setPen( QPen( color, 6 ) );
 
         switch (corners) {
-            case CornerTopLeft|CornerTopRight:
+            case CornersTop:
                 painter->drawLine(frameRect.left() + adjustment, frameRect.bottom(), frameRect.right() - adjustment, frameRect.bottom());
                 break;
 
-            case CornerBottomLeft|CornerBottomRight:
+            case CornersBottom:
                 painter->drawLine(frameRect.left() + adjustment, frameRect.top(), frameRect.right() - adjustment, frameRect.top());
                 break;
 
-            case CornerTopLeft|CornerBottomLeft:
+            case CornersLeft:
                 painter->drawLine(frameRect.right(), frameRect.top() + adjustment, frameRect.right(), frameRect.bottom() - adjustment);
                 break;
 
-            case CornerTopRight|CornerBottomRight:
+            case CornersRight:
                 painter->drawLine(frameRect.left(), frameRect.top() + adjustment, frameRect.left(), frameRect.bottom() - adjustment);
                 break;
-    
+
         }
 
 

--- a/style/adwaitastyle.cpp
+++ b/style/adwaitastyle.cpp
@@ -5727,22 +5727,22 @@ namespace Adwaita
         {
             case QTabBar::RoundedNorth:
             case QTabBar::TriangularNorth:
-                corners = CornerTopLeft|CornerTopRight;
+                corners = CornersTop;
                 break;
 
             case QTabBar::RoundedSouth:
             case QTabBar::TriangularSouth:
-                corners = CornerBottomLeft|CornerBottomRight;
+                corners = CornersBottom;
                 break;
 
             case QTabBar::RoundedWest:
             case QTabBar::TriangularWest:
-                corners = CornerTopLeft|CornerBottomLeft;
+                corners = CornersLeft;
                 break;
 
             case QTabBar::RoundedEast:
             case QTabBar::TriangularEast:
-                corners = CornerTopRight|CornerBottomRight;
+                corners = CornersRight;
                 break;
 
             default: break;
@@ -5971,7 +5971,7 @@ namespace Adwaita
     //______________________________________________________________
     bool Style::drawGroupBoxComplexControl( const QStyleOptionComplex* option, QPainter* painter, const QWidget* widget ) const
     {
-        if (const QStyleOptionGroupBox *groupBox = qstyleoption_cast<const QStyleOptionGroupBox *>(option)) 
+        if (const QStyleOptionGroupBox *groupBox = qstyleoption_cast<const QStyleOptionGroupBox *>(option))
         {
             painter->save();
 


### PR DESCRIPTION
The following patches enable building of adwaita-qt under Windows with Visual Studio 2015.